### PR TITLE
Fixed container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 1.12
+ENV GITBUCKET_VERSION 1.13
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 1.11.1
+ENV GITBUCKET_VERSION 1.12
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.6
+ENV GITBUCKET_VERSION 2.7
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.5
+ENV GITBUCKET_VERSION 2.6
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.3
+ENV GITBUCKET_VERSION 2.4.1
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.0
+ENV GITBUCKET_VERSION 2.1
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 1.13
+ENV GITBUCKET_VERSION 2.0
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-RUN mkdir /gitbucket && curl -o /gitbucket/gitbucket.war -L https://github.com/takezoe/gitbucket/releases/download/1.9/gitbucket.war
+RUN \
+  mkdir /gitbucket && \
+  curl -o /gitbucket/gitbucket.war -L https://github.com/takezoe/gitbucket/releases/download/1.9/gitbucket.war
 
 VOLUME ["/data"]
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 1.9
+ENV GITBUCKET_VERSION 1.10
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM base/devel:latest
 MAINTAINER Reuben Bond, reuben.bond@gmail.com
-RUN yaourt --noconfirm -Syyua jdk
+
+# Install OpenJDK 8
+RUN \
+  pacman -Syyu --noconfirm --noprogress && \
+  pacman-db-upgrade && \
+  pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
 RUN mkdir /gitbucket && curl -o /gitbucket/gitbucket.war -L https://github.com/takezoe/gitbucket/releases/download/1.9/gitbucket.war
 
 VOLUME ["/data"]
 EXPOSE 8080
-CMD /opt/java/bin/java -jar /gitbucket/gitbucket.war --port=8080 --gitbucket.home=/data
+CMD /usr/bin/java -jar /gitbucket/gitbucket.war --port=8080 --gitbucket.home=/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.1
+ENV GITBUCKET_VERSION 2.2.1
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.4.1
+ENV GITBUCKET_VERSION 2.5
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
+ENV GITBUCKET_VERSION 1.9
+
 RUN \
   mkdir /gitbucket && \
-  curl -o /gitbucket/gitbucket.war -L https://github.com/takezoe/gitbucket/releases/download/1.9/gitbucket.war
+  curl -o /gitbucket/gitbucket.war -L https://github.com/takezoe/gitbucket/releases/download/$GITBUCKET_VERSION/gitbucket.war
 
 VOLUME ["/data"]
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 1.10
+ENV GITBUCKET_VERSION 1.11.1
 
 RUN \
   mkdir /gitbucket && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   pacman-db-upgrade && \
   pacman -Syyu --noconfirm --noprogress jre8-openjdk-headless
 
-ENV GITBUCKET_VERSION 2.2.1
+ENV GITBUCKET_VERSION 2.3
 
 RUN \
   mkdir /gitbucket && \


### PR DESCRIPTION
Fixed building the container as the base container requires updates in order to install the JDK.

I tried switching out the `yaourt` command with `pacman` to allow myself the ability to call `pacman-db-upgrade`.
